### PR TITLE
Move non action-specific args to a config class

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Split file into X files of approximately equal row counts. When used in conjunct
 ## Avoiding high memory usage
 CHOPPER was designed with very large files in mind, so avoids loading the entire file to memory where possible. The only situation where this is impossible is where randomization is used (`--shuffles`) _without_ splitting by column values (`--columns`). When splitting by columns, randomization will be performed on the split files, some or all of which may still be quite large, so use the randomization feature with caution whether or not you split by column values.
 
+## TODO
+1. Refactor to skip combining multiple input files when not shuffling, since it is not necessary and potentially expensive.
+2. Use multiprocessing to perform post-column operations in parallel.
+
 ## Authors
 CHOPPER was created by [Joshua Matfess](https://github.com/jsmatfess) of [Table Flip Analytics](https://table-flip.net).
 

--- a/chopper.py
+++ b/chopper.py
@@ -364,7 +364,7 @@ def main() -> None:
         output_ext = in_files[0].suffix
 
         files = [combine_files(in_files, config)]
-        config.to_tmp = False
+        config.is_original = False
     else:
         # If input is a file, use that file's extension for outputs.
         output_ext = input_path.suffix
@@ -378,7 +378,7 @@ def main() -> None:
             new_files.extend(split_by_columns(file, col_list, config))
 
         files = new_files
-        config.to_tmp = False
+        config.is_original = False
 
     # Shuffling must be done before by-row chops for proper randomization.
     if shuffles:
@@ -387,7 +387,7 @@ def main() -> None:
             new_files.extend(shuffle_file(file, shuffles, config))
 
         files = new_files
-        config.to_tmp = False
+        config.is_original = False
 
     if rows:
         new_files = []
@@ -395,7 +395,7 @@ def main() -> None:
             new_files.extend(split_by_rows(file, rows, config))
 
         files = new_files
-        config.to_tmp = False
+        config.is_original = False
 
     if equal:
         new_files = []
@@ -403,7 +403,7 @@ def main() -> None:
             new_files.extend(split_by_equal(file, equal, config))
 
         files = new_files
-        config.to_tmp = False
+        config.is_original = False
 
     for file in files:
         newfile = file


### PR DESCRIPTION
1. Moves CLI arguments that are not function-specific to a new Config class (`encoding`, `delimiter`, `output_dir`, and `is_original`, which was previously called `to_tmp`).
2. Adds a couple TODO reminders.